### PR TITLE
Audit: add entity change subscriber and changeset model

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -103,6 +103,34 @@ class UserRepository extends AbstractRepository
 }
 ```
 
+### Audit logging
+
+`EntityChangeSubscriber` stores entity create/update/delete changes into `Nettrine\Extra\Audit\Changeset` records.
+
+Register services:
+
+```neon
+services:
+	- Nettrine\Extra\Audit\ChangesetFactory('api')
+	- Nettrine\Extra\Audit\EntityChangeSubscriber
+```
+
+Register subscriber into Doctrine event manager (or ORM configuration):
+
+```php
+$eventManager->addEventSubscriber($entityChangeSubscriber);
+```
+
+`ChangesetFactory` supports optional user assignment:
+
+```php
+$changesetFactory->withUserId($userId);
+```
+
+The subscriber ignores unsupported field value types and logs internal errors through `Psr\Log\LoggerInterface`.
+
+`Changeset` entity uses table `AuditChangesets` and stores old/new values as JSON payloads.
+
 ### Utils
 
 We've prepared some utility classes.

--- a/src/Audit/AuditException.php
+++ b/src/Audit/AuditException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\Extra\Audit;
+
+use Nettrine\Extra\Exception\LogicalException;
+
+final class AuditException extends LogicalException
+{
+
+}

--- a/src/Audit/Changeset.php
+++ b/src/Audit/Changeset.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\Extra\Audit;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+use JsonException;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'AuditChangesets')]
+class Changeset
+{
+
+	private const DATETIME_FORMAT = 'Y-m-d H:i:s.u';
+
+	#[ORM\Id]
+	#[ORM\Column(type: 'string', length: 26)]
+	private string $datetime;
+
+	#[ORM\Column(type: 'string', length: 32)]
+	private string $entrypoint;
+
+	#[ORM\Column(type: 'integer', nullable: true)]
+	private ?int $user;
+
+	#[ORM\Column(type: 'string', length: 255)]
+	private string $entityTable;
+
+	#[ORM\Column(type: 'string', length: 128)]
+	private string $entityId;
+
+	#[ORM\Column(type: 'text', nullable: true)]
+	private ?string $oldData;
+
+	#[ORM\Column(type: 'text', nullable: true)]
+	private ?string $newData;
+
+	/**
+	 * @param array<string, mixed>|null $oldData
+	 * @param array<string, mixed>|null $newData
+	 */
+	public function __construct(
+		DateTimeImmutable $datetime,
+		string $entrypoint,
+		string $entityTable,
+		string $entityId,
+		?array $oldData,
+		?array $newData,
+		?int $user,
+	)
+	{
+		$this->datetime = $datetime->format(self::DATETIME_FORMAT);
+		$this->entrypoint = $entrypoint;
+		$this->entityTable = $entityTable;
+		$this->entityId = $entityId;
+		$this->oldData = $this->encode($oldData);
+		$this->newData = $this->encode($newData);
+		$this->user = $user;
+	}
+
+	public function getDatetime(): string
+	{
+		return $this->datetime;
+	}
+
+	public function getEntrypoint(): string
+	{
+		return $this->entrypoint;
+	}
+
+	public function getUser(): ?int
+	{
+		return $this->user;
+	}
+
+	public function getEntityTable(): string
+	{
+		return $this->entityTable;
+	}
+
+	public function getEntityId(): string
+	{
+		return $this->entityId;
+	}
+
+	public function getOldData(): ?string
+	{
+		return $this->oldData;
+	}
+
+	public function getNewData(): ?string
+	{
+		return $this->newData;
+	}
+
+	/**
+	 * @param array<string, mixed>|null $data
+	 */
+	private function encode(?array $data): ?string
+	{
+		if ($data === null) {
+			return null;
+		}
+
+		try {
+			return json_encode($data, JSON_THROW_ON_ERROR);
+		} catch (JsonException $e) {
+			throw new AuditException($e->getMessage(), 0, $e);
+		}
+	}
+
+}

--- a/src/Audit/ChangesetData.php
+++ b/src/Audit/ChangesetData.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\Extra\Audit;
+
+use BackedEnum;
+use Doctrine\ORM\PersistentCollection;
+use Nettrine\Extra\Entity\AbstractEntity;
+
+class ChangesetData
+{
+
+	/** @var array<string, mixed> */
+	private array $data = [];
+
+	/**
+	 * @throws AuditException
+	 */
+	public function add(string $property, mixed $value): void
+	{
+		if ($value instanceof PersistentCollection) {
+			return;
+		}
+
+		$serializable = match (true) {
+			$value instanceof BackedEnum => $value->value,
+			$value instanceof AbstractEntity => $this->resolveEntityId($value, $property),
+			is_scalar($value),
+			$value === null => $value,
+			default => throw new AuditException(sprintf('Unknown changeset value type for "%s".', $property)),
+		};
+
+		$this->data[$property] = $serializable;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function data(): array
+	{
+		return $this->data;
+	}
+
+	private function resolveEntityId(AbstractEntity $entity, string $property): mixed
+	{
+		if (!method_exists($entity, 'getId')) {
+			throw new AuditException(sprintf('Entity value for "%s" does not provide getId().', $property));
+		}
+
+		$reflection = new \ReflectionMethod($entity, 'getId');
+
+		/** @var mixed $id */
+		$id = $reflection->invoke($entity);
+		if (!is_scalar($id) && $id !== null) {
+			throw new AuditException(sprintf('Entity id for "%s" must be scalar or null.', $property));
+		}
+
+		return $id;
+	}
+
+}

--- a/src/Audit/ChangesetFactory.php
+++ b/src/Audit/ChangesetFactory.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\Extra\Audit;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ChangesetFactory
+{
+
+	private ?int $userId = null;
+
+	public function __construct(
+		private readonly string $entrypoint,
+		private readonly EntityManagerInterface $em,
+	)
+	{
+	}
+
+	public function withUserId(?int $userId): self
+	{
+		$this->userId = $userId;
+
+		return $this;
+	}
+
+	public function forCreate(object $entity): Changeset
+	{
+		$uow = $this->em->getUnitOfWork();
+		$changeSet = $uow->getEntityChangeSet($entity);
+
+		$newData = new ChangesetData();
+		foreach ($changeSet as $property => [, $newValue]) {
+			try {
+				$newData->add($property, $newValue);
+			} catch (AuditException) {
+				// Ignore unsupported property values in audit payload.
+			}
+		}
+
+		return $this->create($entity, null, $newData->data());
+	}
+
+	public function forUpdate(object $entity): Changeset
+	{
+		$uow = $this->em->getUnitOfWork();
+		$changeSet = $uow->getEntityChangeSet($entity);
+
+		$oldData = new ChangesetData();
+		$newData = new ChangesetData();
+		foreach ($changeSet as $property => [$oldValue, $newValue]) {
+			try {
+				$oldData->add($property, $oldValue);
+				$newData->add($property, $newValue);
+			} catch (AuditException) {
+				// Ignore unsupported property values in audit payload.
+			}
+		}
+
+		return $this->create($entity, $oldData->data(), $newData->data());
+	}
+
+	public function forDelete(object $entity): Changeset
+	{
+		$uow = $this->em->getUnitOfWork();
+		$originalEntityData = $uow->getOriginalEntityData($entity);
+
+		$oldData = new ChangesetData();
+		foreach ($originalEntityData as $property => $value) {
+			try {
+				$oldData->add($property, $value);
+			} catch (AuditException) {
+				// Ignore unsupported property values in audit payload.
+			}
+		}
+
+		return $this->create($entity, $oldData->data(), null);
+	}
+
+	/**
+	 * @param array<string, mixed>|null $oldData
+	 * @param array<string, mixed>|null $newData
+	 */
+	private function create(object $entity, ?array $oldData, ?array $newData): Changeset
+	{
+		$table = $this->em->getClassMetadata($entity::class)->getTableName();
+		$id = implode('-', array_map($this->normalizeIdentifier(...), $this->em->getUnitOfWork()->getEntityIdentifier($entity)));
+
+		return new Changeset(
+			new DateTimeImmutable(),
+			$this->entrypoint,
+			$table,
+			$id,
+			$oldData,
+			$newData,
+			$this->userId,
+		);
+	}
+
+	private function normalizeIdentifier(mixed $value): string
+	{
+		if (is_scalar($value) || $value === null) {
+			return (string) $value;
+		}
+
+		if ($value instanceof \Stringable) {
+			return (string) $value;
+		}
+
+		throw new AuditException('Entity identifier contains unsupported value type.');
+	}
+
+}

--- a/src/Audit/ChangesetQueue.php
+++ b/src/Audit/ChangesetQueue.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\Extra\Audit;
+
+final class ChangesetQueue
+{
+
+	/** @var list<Changeset> */
+	private array $queue = [];
+
+	public function enqueue(Changeset $changeset): void
+	{
+		$this->queue[] = $changeset;
+	}
+
+	public function dequeue(): ?Changeset
+	{
+		if ($this->queue === []) {
+			return null;
+		}
+
+		return array_shift($this->queue);
+	}
+
+	public function isEmpty(): bool
+	{
+		return $this->queue === [];
+	}
+
+}

--- a/src/Audit/EntityChangeSubscriber.php
+++ b/src/Audit/EntityChangeSubscriber.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\Extra\Audit;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Event\PreRemoveEventArgs;
+use Doctrine\ORM\Events;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+final class EntityChangeSubscriber implements EventSubscriber
+{
+
+	private ChangesetQueue $queue;
+
+	public function __construct(
+		private readonly LoggerInterface $logger,
+		private readonly EntityManagerInterface $em,
+		private readonly ChangesetFactory $changesetFactory,
+	)
+	{
+		$this->queue = new ChangesetQueue();
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	public function getSubscribedEvents(): array
+	{
+		return [
+			Events::postPersist,
+			Events::postUpdate,
+			Events::preRemove,
+			Events::postFlush,
+		];
+	}
+
+	public function postPersist(PostPersistEventArgs $eventArgs): void
+	{
+		$this->log(
+			$eventArgs->getObject(),
+			fn (object $entity): Changeset => $this->changesetFactory->forCreate($entity),
+		);
+	}
+
+	public function postUpdate(PostUpdateEventArgs $eventArgs): void
+	{
+		$this->log(
+			$eventArgs->getObject(),
+			fn (object $entity): Changeset => $this->changesetFactory->forUpdate($entity),
+		);
+	}
+
+	public function preRemove(PreRemoveEventArgs $eventArgs): void
+	{
+		$this->log(
+			$eventArgs->getObject(),
+			fn (object $entity): Changeset => $this->changesetFactory->forDelete($entity),
+		);
+	}
+
+	public function postFlush(): void
+	{
+		if ($this->queue->isEmpty()) {
+			return;
+		}
+
+		while (($changeset = $this->queue->dequeue()) !== null) {
+			$this->em->persist($changeset);
+		}
+
+		$this->em->flush();
+	}
+
+	/**
+	 * @param callable(object): Changeset $factory
+	 */
+	private function log(object $object, callable $factory): void
+	{
+		if ($object instanceof Changeset) {
+			return;
+		}
+
+		try {
+			$changeset = $factory($object);
+			$this->queue->enqueue($changeset);
+		} catch (Throwable $e) {
+			$this->logger->error($e->getMessage());
+		}
+	}
+
+}

--- a/tests/Cases/Audit/ChangesetData.phpt
+++ b/tests/Cases/Audit/ChangesetData.phpt
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Audit;
+
+use Contributte\Tester\Toolkit;
+use Nettrine\Extra\Audit\AuditException;
+use Nettrine\Extra\Audit\ChangesetData;
+use Tester\Assert;
+use Tests\Fixtures\Audit\EntityWithId;
+use Tests\Fixtures\Audit\LocalAuditState;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$data = new ChangesetData();
+
+	$data->add('string', 'A');
+	$data->add('int', 42);
+	$data->add('float', 3.14);
+	$data->add('bool', true);
+	$data->add('null', null);
+	$data->add('enum', LocalAuditState::Ready);
+	$data->add('entity', new EntityWithId(15));
+
+	Assert::same([
+		'string' => 'A',
+		'int' => 42,
+		'float' => 3.14,
+		'bool' => true,
+		'null' => null,
+		'enum' => 'ready',
+		'entity' => 15,
+	], $data->data());
+});
+
+Toolkit::test(function (): void {
+	$data = new ChangesetData();
+
+	Assert::exception(
+		function () use ($data): void {
+			$data->add('unsupported', new \stdClass());
+		},
+		AuditException::class,
+	);
+});

--- a/tests/Cases/Audit/ChangesetFactory.phpt
+++ b/tests/Cases/Audit/ChangesetFactory.phpt
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Audit;
+
+use Contributte\Tester\Toolkit;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\UnitOfWork;
+use Mockery;
+use Nettrine\Extra\Audit\ChangesetFactory;
+use Tester\Assert;
+use Tests\Fixtures\Audit\DummyEntity;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$entity = new DummyEntity();
+
+	$uow = Mockery::mock(UnitOfWork::class);
+	$uow->shouldReceive('getEntityChangeSet')->with($entity)->once()->andReturn([
+		'name' => [null, 'Felix'],
+		'invalid' => [null, new \stdClass()],
+	]);
+	$uow->shouldReceive('getEntityIdentifier')->with($entity)->once()->andReturn(['id' => 10]);
+
+	$metadata = new ClassMetadata(DummyEntity::class);
+	$metadata->setPrimaryTable(['name' => 'dummy_table']);
+
+	$em = Mockery::mock(EntityManagerInterface::class);
+	$em->shouldReceive('getUnitOfWork')->times(2)->andReturn($uow);
+	$em->shouldReceive('getClassMetadata')->with(DummyEntity::class)->once()->andReturn($metadata);
+
+	$factory = (new ChangesetFactory('cli', $em))->withUserId(5);
+	$changeset = $factory->forCreate($entity);
+
+	Assert::same('cli', $changeset->getEntrypoint());
+	Assert::same('dummy_table', $changeset->getEntityTable());
+	Assert::same('10', $changeset->getEntityId());
+	Assert::same(5, $changeset->getUser());
+	Assert::null($changeset->getOldData());
+	Assert::same(['name' => 'Felix'], json_decode((string) $changeset->getNewData(), true));
+
+	Mockery::close();
+});
+
+Toolkit::test(function (): void {
+	$entity = new DummyEntity();
+
+	$uow = Mockery::mock(UnitOfWork::class);
+	$uow->shouldReceive('getEntityChangeSet')->with($entity)->once()->andReturn([
+		'name' => ['Felix', 'F3l1x'],
+	]);
+	$uow->shouldReceive('getOriginalEntityData')->with($entity)->once()->andReturn([
+		'name' => 'F3l1x',
+	]);
+	$uow->shouldReceive('getEntityIdentifier')->with($entity)->times(2)->andReturn(['id' => 11]);
+
+	$metadata = new ClassMetadata(DummyEntity::class);
+	$metadata->setPrimaryTable(['name' => 'dummy_table']);
+
+	$em = Mockery::mock(EntityManagerInterface::class);
+	$em->shouldReceive('getUnitOfWork')->times(4)->andReturn($uow);
+	$em->shouldReceive('getClassMetadata')->with(DummyEntity::class)->times(2)->andReturn($metadata);
+
+	$factory = new ChangesetFactory('worker', $em);
+	$update = $factory->forUpdate($entity);
+	$delete = $factory->forDelete($entity);
+
+	Assert::same(['name' => 'Felix'], json_decode((string) $update->getOldData(), true));
+	Assert::same(['name' => 'F3l1x'], json_decode((string) $update->getNewData(), true));
+	Assert::same(['name' => 'F3l1x'], json_decode((string) $delete->getOldData(), true));
+	Assert::null($delete->getNewData());
+
+	Mockery::close();
+});

--- a/tests/Cases/Audit/ChangesetQueue.phpt
+++ b/tests/Cases/Audit/ChangesetQueue.phpt
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Audit;
+
+use Contributte\Tester\Toolkit;
+use DateTimeImmutable;
+use Nettrine\Extra\Audit\Changeset;
+use Nettrine\Extra\Audit\ChangesetQueue;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$queue = new ChangesetQueue();
+
+	Assert::true($queue->isEmpty());
+	Assert::null($queue->dequeue());
+
+	$first = new Changeset(new DateTimeImmutable('2026-01-01 10:00:00.000000'), 'api', 'users', '1', null, ['name' => 'Felix'], null);
+	$second = new Changeset(new DateTimeImmutable('2026-01-01 10:00:01.000000'), 'api', 'users', '2', ['name' => 'Felix'], ['name' => 'F3l1x'], 7);
+
+	$queue->enqueue($first);
+	$queue->enqueue($second);
+
+	Assert::false($queue->isEmpty());
+	Assert::same($first, $queue->dequeue());
+	Assert::same($second, $queue->dequeue());
+	Assert::null($queue->dequeue());
+	Assert::true($queue->isEmpty());
+});

--- a/tests/Fixtures/Audit/DummyEntity.php
+++ b/tests/Fixtures/Audit/DummyEntity.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Audit;
+
+final class DummyEntity
+{
+
+}

--- a/tests/Fixtures/Audit/EntityWithId.php
+++ b/tests/Fixtures/Audit/EntityWithId.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Audit;
+
+use Nettrine\Extra\Entity\AbstractEntity;
+
+final class EntityWithId extends AbstractEntity
+{
+
+	public function __construct(
+		private readonly int $id,
+	)
+	{
+	}
+
+	public function getId(): int
+	{
+		return $this->id;
+	}
+
+}

--- a/tests/Fixtures/Audit/LocalAuditState.php
+++ b/tests/Fixtures/Audit/LocalAuditState.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Audit;
+
+enum LocalAuditState: string
+{
+
+	case Ready = 'ready';
+
+}


### PR DESCRIPTION
## Summary
- add a new `Nettrine\Extra\Audit` module with `Changeset` entity, `ChangesetFactory`, queue, and `EntityChangeSubscriber` for create/update/delete audit logging
- introduce `AuditException` and robust changeset value normalization (scalars, enums, entity IDs, nullable values)
- add audit-focused tests and extend `.docs/README.md` with subscriber registration and usage

## Testing
- vendor/bin/tester -s -p php --colors 1 -C tests/Cases
- vendor/bin/phpstan analyse -c phpstan.neon
- vendor/bin/phpcs --standard=ruleset.xml --encoding=utf-8 --extensions=\"php,phpt\" --colors -nsp src tests