### PR TITLE
CI: replace phpdbg with php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace `-p phpdbg` with `-p php` in the `coverage` target so this repository follows the org-wide coverage runner migration.

## Motivation

Issue contributte/contributte#73 tracks removing `phpdbg` from Contributte coverage targets. This keeps `doctrine-extra` aligned with that change.

## Changes

- switch both `coverage` target branches in `Makefile` from `phpdbg` to `php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [ ] Manual verification (if applicable)

What changed: the Makefile coverage target now uses `php` instead of `phpdbg`.
Why: this repository is part of the org-wide migration away from `phpdbg` in coverage runs.

Local note: `make coverage` currently fails in this environment because PHP does not have Xdebug or PCOV loaded, so local coverage could not be fully verified here.